### PR TITLE
Use ct.pinterest.com insteam of widgets

### DIFF
--- a/resources/adblock/data.js
+++ b/resources/adblock/data.js
@@ -110,7 +110,7 @@ const data = {
             "https://analytics.twitter.com"
         ],
         "LinkedIn": ["https://ads.linkedin.com", "https://analytics.pointdrive.linkedin.com"],
-        "Pinterest": ["https://ads.pinterest.com", "https://log.pinterest.com", "https://widgets.pinterest.com",
+        "Pinterest": ["https://ads.pinterest.com", "https://log.pinterest.com", "https://ct.pinterest.com",
             "https://analytics.pinterest.com", "https://trk.pinterest.com"
         ],
         "Reddit": ["https://ads.reddit.com", "https://stats.redditmedia.com", "https://rereddit.com",

--- a/src/d3host.txt
+++ b/src/d3host.txt
@@ -185,7 +185,7 @@ ff02::3 ip6-allhosts
 #Pinterest
 0.0.0.0 ads.pinterest.com
 0.0.0.0 log.pinterest.com
-0.0.0.0 widgets.pinterest.com
+0.0.0.0 ct.pinterest.com
 0.0.0.0 analytics.pinterest.com
 0.0.0.0 trk.pinterest.com
 


### PR DESCRIPTION
Can't properly block  `https://widgets.pinterest.com` without breaking the site (not a tracker, Just displays how many times was shared) .  Using the pinterest tracker `https://ct.pinterest.com` would be a better fit here.

https://publicwww.com/websites/%22ct.pinterest.com%22/